### PR TITLE
Add failing test for ef core value conversion

### DIFF
--- a/test/Bulk.Test/BulkInsertOperationsTest.cs
+++ b/test/Bulk.Test/BulkInsertOperationsTest.cs
@@ -440,5 +440,30 @@ namespace Bulk.Test
             var items = Enumerable.Range(0, 100000).Select(p => new SimpleTableWithIdentity { Title = $"Bla{p}" });
             await ctx.BulkInsertAsync(items, p => p.PropagateValues(false));
         }
+
+        [Fact]
+        public async Task BulkInsertUriWithStringConverter()
+        {
+            var provider = GetServiceProvider();
+            var context = provider.GetService<TestContext>();
+
+            Func<int, SimpleTableWithUri> mapStringToEntity =
+                x => new SimpleTableWithUri
+                {
+                    Id = x,
+                    Uri = new Uri($"https://loclahost:8080/test-uri{x}")
+                };
+
+            var entities = Enumerable.Range(0, 10)
+                .Select(mapStringToEntity);
+
+            await context.BulkInsertAsync(entities);
+
+            var items = await context.SimpleTableWithUri
+                .ToListAsync();
+
+            Assert.Equal(10, items.Count);
+        }
+
     }
 }

--- a/test/Bulk.Test/Migrations/20220304090552_AddUriConversionTable.Designer.cs
+++ b/test/Bulk.Test/Migrations/20220304090552_AddUriConversionTable.Designer.cs
@@ -4,14 +4,16 @@ using Bulk.Test;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bulk.Test.Migrations
 {
     [DbContext(typeof(TestContext))]
-    partial class TestContextModelSnapshot : ModelSnapshot
+    [Migration("20220304090552_AddUriConversionTable")]
+    partial class AddUriConversionTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/test/Bulk.Test/Migrations/20220304090552_AddUriConversionTable.cs
+++ b/test/Bulk.Test/Migrations/20220304090552_AddUriConversionTable.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bulk.Test.Migrations
+{
+    public partial class AddUriConversionTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SimpleTableWithUri",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Uri = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SimpleTableWithUri", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SimpleTableWithUri");
+        }
+    }
+}

--- a/test/Bulk.Test/Model/SimpleTableWithUri.cs
+++ b/test/Bulk.Test/Model/SimpleTableWithUri.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Bulk.Test.Model
+{
+    public class SimpleTableWithUri
+    {
+        public int Id { get; set; }
+
+        public Uri Uri { get; set; }
+    }
+}

--- a/test/Bulk.Test/TestContext.cs
+++ b/test/Bulk.Test/TestContext.cs
@@ -20,6 +20,8 @@ namespace Bulk.Test
 
         public DbSet<SimpleTableWithShadowProperty> SimpleTableWithShadowProperty { get; set; }
 
+        public DbSet<SimpleTableWithUri> SimpleTableWithUri { get; set; }
+
         public override void Dispose()
         {
             base.Dispose();
@@ -42,6 +44,13 @@ namespace Bulk.Test
             entity.Property<string>("Description_en").HasMaxLength(200);
 
             entity.Property(p => p.BoolFlag).HasDefaultValue(false);
+
+
+            modelBuilder.Entity<SimpleTableWithUri>()
+                .Property(p => p.Uri)
+                .HasConversion(
+                    v => v.ToString(),
+                    v => new Uri(v));
         }
     }
 }


### PR DESCRIPTION
- Add new table with migration and dbset to test dbContext
- Add failing test `BulkInsertUriWithStringConverter()` to `BulkInsertOperationsTest` suite

Ref: #7